### PR TITLE
Add regression tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_congestion.py
+++ b/tests/test_congestion.py
@@ -1,0 +1,17 @@
+import numpy as np
+from analyzer.congestion_detector import CongestionDetector
+
+
+def test_congestion_detection():
+    detector = CongestionDetector(displacement_threshold=2.0, vehicle_count_threshold=2)
+    detections1 = [
+        {"bbox": [10, 10, 20, 20]},
+        {"bbox": [30, 30, 40, 40]},
+    ]
+    assert detector.update(detections1) is False
+
+    detections2 = [
+        {"bbox": [11, 10, 21, 20]},
+        {"bbox": [31, 30, 41, 40]},
+    ]
+    assert detector.update(detections2) is True

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,0 +1,26 @@
+import numpy as np
+import torch
+import types
+
+from detector.yolo_detector import YOLODetector
+
+
+def test_yolo_detector(monkeypatch):
+    class DummyTensor(list):
+        def tolist(self):
+            return self
+
+    class DummyModel:
+        def __init__(self):
+            self.names = {0: "car"}
+        def to(self, device):
+            return self
+        def __call__(self, frame):
+            return types.SimpleNamespace(xyxy=[DummyTensor([[10, 10, 20, 20, 0.9, 0]])])
+
+    monkeypatch.setattr(torch.hub, "load", lambda *a, **k: DummyModel())
+
+    det = YOLODetector("fake.pt", device="cpu")
+    frame = np.zeros((64, 64, 3), dtype=np.uint8)
+    out = det.detect(frame)
+    assert out == [{"bbox": [10, 10, 20, 20], "conf": 0.9, "label": "car"}]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,45 @@
+import argparse
+import urllib.request
+
+import main
+
+
+def test_main_pipeline(tmp_path, monkeypatch):
+    url = (
+        "https://raw.githubusercontent.com/opencv/opencv/master/samples/data/"
+        "Megamind.avi"
+    )
+    input_video = tmp_path / "test.avi"
+    urllib.request.urlretrieve(url, str(input_video))
+    out_video = tmp_path / 'out.mp4'
+    log_file = tmp_path / 'log.txt'
+
+    class DummyDetector:
+        def __init__(self, *a, **k):
+            pass
+        def detect(self, frame):
+            return [{"bbox": [10, 10, 20, 20], "conf": 0.9, "label": "car"}]
+
+    class DummyCaption:
+        def caption(self, frame):
+            return "dummy"
+
+    monkeypatch.setattr(main, 'YOLODetector', DummyDetector)
+    monkeypatch.setattr(main, 'CaptionGenerator', lambda: DummyCaption())
+
+    args = argparse.Namespace(
+        input=str(input_video),
+        output=str(out_video),
+        log=str(log_file),
+        model='fake.pt',
+        device='cpu',
+        caption=True,
+    )
+
+    main.main(args)
+
+    assert out_video.exists()
+    assert log_file.exists()
+    lines = log_file.read_text().splitlines()
+    assert len(lines) > 0
+    assert all(line.endswith('Free') for line in lines)


### PR DESCRIPTION
## Summary
- add regression tests for congestion analysis and YOLO wrapper
- add end-to-end pipeline test using a tiny sample video
- include pytest config to ensure repo root is on `sys.path`
- remove local test video and download sample during test

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543e911c788322915728f59fb1f345