### PR TITLE
Fix demo launch and use remote sample images

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ The script reports precision, recall, F1 and AUC and saves ROC, PR and confusion
 ## Demo
 Launch a simple Streamlit interface:
 ```bash
-python main.py demo --config configs/config_classify.yaml --ckpt checkpoints/model.pt
+python main.py demo --ckpt checkpoints/model.pt
 ```
-Upload an image and enter a prompt such as "How congested is this road?" to get the predicted probability.
+This command now starts Streamlit automatically. Upload an image and enter a prompt such as "How congested is this road?" to get the predicted probability.
 
 ## Technical summary
 | Component | Details |
@@ -73,11 +73,11 @@ Upload an image and enter a prompt such as "How congested is this road?" to get 
 | AUC (test) | 0.86 |
 
 ## Sample Data
-The repository includes a minimal `dataset.csv` with three examples referencing images hosted online. Example output:
+The repository includes a `sample_data/dataset.csv` that references three remote images by URL. Example entry:
 ```
-Input URL: https://i.imgur.com/ExdKOOz.png
-Prompt: "heavy traffic"
-Prediction: 0.75 (75% congestion)
+image: https://picsum.photos/seed/heavy-traffic/640/480
+text: "heavy traffic"
+label: 1
 ```
 
 ## How to Extend This Project

--- a/main.py
+++ b/main.py
@@ -1,11 +1,11 @@
 import argparse
 import logging
 from pathlib import Path
+import subprocess
 import yaml
 
 from train import train
 from evaluate import evaluate
-from demo import run_app
 
 
 def setup_logging(mode: str, log_dir: str = "logs"):
@@ -44,7 +44,19 @@ def main():
     elif args.mode == "eval":
         evaluate(args)
     else:
-        run_app(args)
+        cmd = [
+            "streamlit",
+            "run",
+            str(Path(__file__).parent / "demo.py"),
+            "--",
+            "--ckpt",
+            args.ckpt,
+            "--data-dir",
+            args.data_dir,
+        ]
+        if args.offline:
+            cmd.append("--offline")
+        subprocess.run(cmd, check=True)
 
 
 if __name__ == "__main__":

--- a/sample_data/dataset.csv
+++ b/sample_data/dataset.csv
@@ -1,4 +1,4 @@
-image_url,text,label
-https://i.imgur.com/ExdKOOz.png,"heavy traffic",1
-https://i.imgur.com/oaJKGqe.jpeg,"traffic jam",1
-https://i.imgur.com/tEcAE1I.jpeg,"clear road",0
+image,text,label
+https://picsum.photos/seed/heavy-traffic/640/480,"heavy traffic",1
+https://picsum.photos/seed/traffic-jam/640/480,"traffic jam",1
+https://picsum.photos/seed/clear-road/640/480,"clear road",0

--- a/utils.py
+++ b/utils.py
@@ -46,6 +46,8 @@ class TrafficDataset(Dataset):
                     url = row.get("image_url") or row.get("image")
                     text = row.get("text", "")
                     label = int(row.get("label", 0))
+                    if url and not str(url).startswith("http"):
+                        url = (self.root / url).as_posix()
                     self.samples.append((url, text, label))
         else:
             for img in sorted((self.root / "images").glob("*.jpg")):


### PR DESCRIPTION
## Summary
- Launch Streamlit automatically when running `python main.py demo`
- Resolve local image paths in `TrafficDataset`
- Reference three remote placeholder images in `sample_data/dataset.csv` and document their usage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e3a9f620083229f8c7d676eebe64f