### PR TITLE
Enhance Streamlit demo with robust features

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,25 @@ python main.py eval --config configs/config_classify.yaml --ckpt checkpoints/mod
 The script reports precision, recall, F1 and AUC and saves ROC, PR and confusion matrix plots to `eval_outputs/`.
 
 ## Demo
-Launch a simple Streamlit interface:
+An interactive Streamlit interface showcases the full model.
+
+### Launching the demo
+Use the provided script which sets sensible defaults and checks that paths exist:
 ```bash
-python main.py demo --ckpt checkpoints/model.pt
+./run_demo.sh --ckpt checkpoints/model.pt --config config.yaml
 ```
-This command now starts Streamlit automatically. Upload an image and enter a prompt such as "How congested is this road?" to get the predicted probability.
+Both flags are optional; missing files trigger a warning and built‑in defaults are used.
+
+### Features
+- Upload an image **or** choose one from the sample gallery.
+- Enter a custom prompt and optionally multiple prompt templates.
+- Toggle between **classification** and **contrastive** heads.
+- View congestion probability with a confidence bar and raw logit.
+- Inspect cross‑attention heatmaps overlaid on the image.
+- In contrastive mode, the demo retrieves the most similar training image and caption.
+- Expand the **Model information** section to see architecture details and YAML config values.
+
+Query history is stored in `logs/demo_queries.log` for experimentation.
 
 ## Technical summary
 | Component | Details |

--- a/run_demo.sh
+++ b/run_demo.sh
@@ -1,2 +1,38 @@
 #!/bin/bash
-streamlit run demo.py "$@"
+
+# Simple wrapper to launch the Streamlit demo with sensible defaults.
+# Users can optionally pass ``--ckpt`` and ``--config`` paths which will be
+# forwarded to ``demo.py``. If a path is missing the script falls back to
+# defaults and prints a warning instead of failing.
+
+CKPT=""
+CONFIG=""
+ARGS=()
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --ckpt)
+      CKPT="$2"; shift 2;;
+    --config)
+      CONFIG="$2"; shift 2;;
+    *)
+      ARGS+=("$1"); shift;;
+  esac
+done
+
+# Default paths if none provided
+CKPT=${CKPT:-checkpoints/model.pt}
+CONFIG=${CONFIG:-config.yaml}
+
+if [ ! -f "$CKPT" ]; then
+  echo "[run_demo] Warning: checkpoint '$CKPT' not found; the model will use random weights." >&2
+fi
+
+CONFIG_ARG=""
+if [ -f "$CONFIG" ]; then
+  CONFIG_ARG="--config $CONFIG"
+else
+  echo "[run_demo] Warning: config '$CONFIG' not found; internal defaults will be used." >&2
+fi
+
+streamlit run demo.py -- --ckpt "$CKPT" $CONFIG_ARG "${ARGS[@]}"


### PR DESCRIPTION
## Summary
- overhaul Streamlit demo with image validation, sample gallery, heatmaps and model info
- add run_demo.sh wrapper that handles checkpoint and config paths gracefully
- document demo launch and features in README

## Testing
- `pytest`
- simulated model forward pass on sample image


------
https://chatgpt.com/codex/tasks/task_e_688e66eea7d48322a32f7e9e83876a06