### PR TITLE
Add HuggingFace dataset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ text: "heavy traffic"
 label: 1
 ```
 
+## Training with an Online Dataset
+The training and evaluation scripts can consume image–caption data hosted on Hugging Face. The
+[Flickr8k](https://huggingface.co/datasets/Naveengo/flickr8k) dataset (8k images with captions) is used as an example.
+Captions containing traffic‑related keywords ("car", "bus", "truck", "traffic", "vehicle") are labeled as positive.
+
+```bash
+# train on 100 Flickr8k samples
+python train.py --hf-dataset Naveengo/flickr8k --hf-split train --limit 100 --epochs 1
+# evaluate on 50 validation samples
+python evaluate.py --hf-dataset Naveengo/flickr8k --hf-split test --limit 50 --ckpt checkpoints/model.pt
+```
+
 ## How to Extend This Project
 - **New tasks**: Implement a custom head in `heads.py` and list it in `model.heads` in your config. Examples include captioning or VQA.
 - **Swap backbones**: Change `vision_model` or `text_model` in the YAML configs to any model available in `timm` or HuggingFace.

--- a/cli.py
+++ b/cli.py
@@ -13,5 +13,8 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument("--epochs", type=int, default=5, help="number of training epochs")
     parser.add_argument("--batch-size", type=int, default=4, help="mini-batch size")
     parser.add_argument("--lr", type=float, default=1e-4, help="learning rate")
+    parser.add_argument("--hf-dataset", default=None, help="HuggingFace dataset name")
+    parser.add_argument("--hf-split", default="train", help="dataset split to use")
+    parser.add_argument("--limit", type=int, default=None, help="limit number of samples")
     return parser
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -15,7 +15,7 @@ from sklearn.metrics import (
 from torch.utils.data import DataLoader
 
 from model import VisionLanguageTransformer, VLTConfig
-from utils import TrafficDataset
+from utils import TrafficDataset, HFTrafficDataset
 from cli import get_parser
 
 
@@ -36,7 +36,13 @@ def evaluate(args):
     model.eval()
     logging.info("Loaded model from %s", args.ckpt)
 
-    dataset = TrafficDataset(data_cfg.get("root", args.data_dir), config.text_model, offline=args.offline)
+    ds_name = data_cfg.get("hf_dataset", getattr(args, "hf_dataset", None))
+    split = data_cfg.get("split", getattr(args, "hf_split", "test"))
+    limit = data_cfg.get("limit", getattr(args, "limit", None))
+    if ds_name:
+        dataset = HFTrafficDataset(ds_name, split, config.text_model, limit=limit, offline=args.offline)
+    else:
+        dataset = TrafficDataset(data_cfg.get("root", args.data_dir), config.text_model, offline=args.offline)
     loader = DataLoader(dataset, batch_size=args.batch_size)
 
     preds = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ timm
 pyyaml
 matplotlib
 pytest
+datasets

--- a/train.py
+++ b/train.py
@@ -10,7 +10,7 @@ from torch.cuda.amp import GradScaler, autocast
 from sklearn.metrics import f1_score
 
 from model import VisionLanguageTransformer, VLTConfig
-from utils import TrafficDataset
+from utils import TrafficDataset, HFTrafficDataset
 from cli import get_parser
 
 
@@ -32,7 +32,13 @@ def train(args):
 
     model = VisionLanguageTransformer(config, offline=args.offline).to(device)
 
-    dataset = TrafficDataset(data_cfg.get("root", args.data_dir), config.text_model, offline=args.offline)
+    ds_name = data_cfg.get("hf_dataset", getattr(args, "hf_dataset", None))
+    split = data_cfg.get("split", getattr(args, "hf_split", "train"))
+    limit = data_cfg.get("limit", getattr(args, "limit", None))
+    if ds_name:
+        dataset = HFTrafficDataset(ds_name, split, config.text_model, limit=limit, offline=args.offline)
+    else:
+        dataset = TrafficDataset(data_cfg.get("root", args.data_dir), config.text_model, offline=args.offline)
     batch_size = int(train_cfg.get("batch_size", args.batch_size))
     loader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
 


### PR DESCRIPTION
## Summary
- allow training and evaluation on HuggingFace datasets with new `HFTrafficDataset`
- expose `--hf-dataset` options in CLI and docs for using the Flickr8k image-caption set
- document how to label captions with traffic keywords and run on Flickr8k

## Testing
- `pytest`
- `python train.py --hf-dataset Naveengo/flickr8k --hf-split train --limit 100 --epochs 1 --batch-size 8`
- `python evaluate.py --hf-dataset Naveengo/flickr8k --hf-split train --limit 50 --ckpt checkpoints/model.pt`


------
https://chatgpt.com/codex/tasks/task_e_68925dc094bc83229e0fcad66067b83f