### PR TITLE
docs: clarify project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,125 +1,63 @@
 # Vision-Language Traffic Congestion Detector
 
-This project showcases a research‑grade **vision‑language transformer** for detecting road congestion. A ViT visual backbone and stacked cross‑attention fuse images with text prompts. The model supports both classification and contrastive alignment for CLIP‑style retrieval.
-
-## Project Highlights
-- ✅ Multi-head VLT: Classification + Contrastive heads
-- ✅ Modular cross-modal fusion layers
-- ✅ ViT encoder with optional fine-tuning
-- ✅ Configurable, reproducible training
-- ✅ Attention visualization support
-
-## Project Motivation
-Real-world traffic monitoring benefits from understanding both images and descriptive text. A vision-language model allows flexible prompting (e.g., "heavy traffic" vs "clear road") and can align images with language for advanced retrieval.
-
-## Why this project matters
-- Vision-language learning is key for autonomous driving analytics
-- Congestion detection requires both spatial and semantic reasoning
-- Demo-ready interface highlights real-world application
+A small prototype that combines a frozen Vision Transformer and DistilBERT to score traffic congestion. The model accepts a road image and a short text prompt such as "heavy traffic" or "clear road" and returns a probability that the scene matches the prompt. When the contrastive head is enabled, it can also retrieve similar examples from the training data.
 
 ## Architecture
-- **Architecture overview**
-```
-[Image] --ViT--> patch tokens --+
-[Prompt] --Text Encoder--> text tokens --+--> Cross-Attention × N --> CLS --> Classifier
-```
-- **Vision encoder**: ViT backbone from `timm` (frozen)
-- **Text encoder**: HuggingFace transformer (frozen)
-- **Fusion**: project both features to a shared space and pass through several cross‑attention blocks with residual connections
-- **Optional**: CLIP‑style contrastive head for zero‑shot retrieval
+### Encoders
+- **Vision Transformer (ViT)** – turns the image into patch embeddings.
+- **DistilBERT** – embeds the text prompt.
 
-## Installation
+Both encoders stay frozen.
+
+### Fusion
+Two cross-attention blocks let text tokens attend to image tokens, producing fused representations that capture how the prompt relates to the scene.
+
+### Heads
+- **Classification head** – linear layer over the fused `[CLS]` token trained with binary cross-entropy to predict congestion.
+- **Contrastive head** – projects averaged image tokens and the text `[CLS]` into a shared embedding space. An InfoNCE loss aligns matching image-text pairs and separates mismatched pairs, enabling retrieval.
+
+## Data and Training
+Training expects a CSV file with `image_url`, `text`, and `label` columns (see `sample_data/dataset.csv`). Images download on demand and cache locally. A YAML config file sets hyperparameters, augmentation, and whether the contrastive head is active. Checkpoints go to `checkpoints/` and TensorBoard logs to `runs/`.
+
+## Usage
+### Setup
+Install dependencies and run tests:
+
 ```bash
 pip install -r requirements.txt
+pytest
 ```
-Pass `--offline` to the scripts if pretrained models are already cached and no download is possible.
 
-## Training
-All experiment settings are stored in `config.yaml`. Adjust the number of cross-attention layers, hidden dimensions and optimizer settings there.
-Prepare a `dataset.csv` file with columns `image_url`, `text`, and `label` as in `sample_data/dataset.csv`.
+### Train
+
 ```bash
 python main.py train --config configs/config_classify.yaml
 ```
-Checkpoints and logs are written to the directory specified in the config.
 
-## Evaluation
+### Evaluate
+
 ```bash
 python main.py eval --config configs/config_classify.yaml --ckpt checkpoints/model.pt
 ```
-The script reports precision, recall, F1 and AUC and saves ROC, PR and confusion matrix plots to `eval_outputs/`.
 
-## Demo
-An interactive Streamlit interface showcases the full model.
+### Demo
 
-### Launching the demo
-Use the provided script which sets sensible defaults and checks that paths exist:
 ```bash
 ./run_demo.sh --ckpt checkpoints/model.pt --config config.yaml
 ```
-Both flags are optional; missing files trigger a warning and built‑in defaults are used.
 
-### Features
-- Upload an image **or** choose one from the sample gallery.
-- Enter a custom prompt and optionally multiple prompt templates.
-- Toggle between **classification** and **contrastive** heads.
-- View congestion probability with a confidence bar and raw logit.
-- Inspect cross‑attention heatmaps overlaid on the image.
-- In contrastive mode, the demo retrieves the most similar training image and caption.
-- Expand the **Model information** section to see architecture details and YAML config values.
-
-Query history is stored in `logs/demo_queries.log` for experimentation.
-
-## Technical summary
-| Component | Details |
-|-----------|---------|
-| Vision backbone | `vit_base_patch16_224` frozen |
-| Text backbone | HuggingFace DistilBERT (frozen) |
-| Cross-attention layers | 2 |
-| Hidden dimension | 256 |
-| Loss | Binary cross-entropy or hybrid with contrastive |
-| Metrics | Precision, Recall, F1, AUC |
-| Parameters | ~80M (encoders frozen) |
-
-### Example Results
-| Metric | Value |
-|--------|-------|
-| F1 (test) | 0.78 |
-| AUC (test) | 0.86 |
-
-## Sample Data
-The repository includes a `sample_data/dataset.csv` that references three remote images by URL. Example entry:
-```
-image: https://picsum.photos/seed/heavy-traffic/640/480
-text: "heavy traffic"
-label: 1
-```
-
-## Training with an Online Dataset
-The training and evaluation scripts can consume image–caption data hosted on Hugging Face. The
-[Flickr8k](https://huggingface.co/datasets/Naveengo/flickr8k) dataset (8k images with captions) is used as an example.
-Captions containing traffic‑related keywords ("car", "bus", "truck", "traffic", "vehicle") are labeled as positive.
+### Example CLI Query
+After training, you can obtain a congestion score and nearest example:
 
 ```bash
-# train on 100 Flickr8k samples
-python train.py --hf-dataset Naveengo/flickr8k --hf-split train --limit 100 --epochs 1
-# evaluate on 50 validation samples
-python evaluate.py --hf-dataset Naveengo/flickr8k --hf-split test --limit 50 --ckpt checkpoints/model.pt
+python cli.py --ckpt checkpoints/model.pt --image sample_data/jam.jpg --text "heavy traffic"
 ```
 
-## How to Extend This Project
-- **New tasks**: Implement a custom head in `heads.py` and list it in `model.heads` in your config. Examples include captioning or VQA.
-- **Swap backbones**: Change `vision_model` or `text_model` in the YAML configs to any model available in `timm` or HuggingFace.
-- **Fusion depth & tuning**: Adjust `num_layers` or unfreeze encoders for deeper fusion/fine-tuning.
-- **Prompt templates**: Provide multiple prompt templates in the demo sidebar to ensemble predictions.
+## Limitations and Future Work
+- Small dataset and limited tuning yield modest accuracy.
+- Not optimized for production deployment.
+- Future improvements could include fine-tuning the encoders, richer augmentations, and multi-level congestion labels.
 
-```
-[Image] -> ViT -> patches
-[Prompt] -> Text Encoder -> tokens
-                |
-          Cross Attention x N
-                |
-              Heads
-```
-
-The system aids **autonomous driving**, intelligent transportation systems and **urban planning** by connecting visual cues with contextual language for accurate congestion understanding.
+## Project scope
+This is a personal learning project that demonstrates how to wire together vision and language modules for basic traffic analysis.
 


### PR DESCRIPTION
## Summary
- Clarify in README that the project is a small prototype combining frozen ViT and DistilBERT to score traffic congestion
- Describe encoders, cross-attention fusion, classification and contrastive heads in straightforward terms
- State personal learning scope and remove references to interviews

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ddef9ffc88322a9c76a8d21e75b8f